### PR TITLE
Add address validation utility

### DIFF
--- a/src/utils/address.js
+++ b/src/utils/address.js
@@ -1,0 +1,6 @@
+export const validAddress = address => {
+  if (/^(0x)?[0-9a-fA-F]{40}$/i.test(address))
+    // check if address consists of '0x' and 40 hexadecimal characters
+    return true
+  return false
+}


### PR DESCRIPTION
This PR only partially resolves #20.
It adds a function that is able to check if address is valid (simple regex), but isn't able to check its checksum.
Validating checksum of an address requires calculating sha3 of it and it would require adding `web3.js` as dependency. Is this something you want to do @epiqueras @n1c01a5?