### PR TITLE
Add string (address) shortening utility function

### DIFF
--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -27,3 +27,22 @@ export function camelToTitleCase(str) {
       p1 ? p1.toUpperCase() : p2 ? p2[0] + ' ' + p2[1] : ' ' + p3
   )
 }
+
+/**
+ * Shortens a string to a given length, by default hiding the middle of it. e.g. 'Hello World!', 7 => 'He...d!'
+ * @param {string} str - The string to shorten.
+ * @param {number} length - The length to which text should be shortened.
+ * @param {{position: string}} [options={position:middle}] - Object with an option determining which part of string should be removed during shortening.
+ * @returns {string} - The shortened string.
+ */
+export function shorten(str, length, { position = 'middle' } = {}) {
+  if (length >= str.length) return str
+  if (length < 5) return str.substr(0, length)
+
+  if (position === 'middle')
+    return `${str.substr(0, Math.floor(length / 2) - 1)}...${str.substr(
+      str.length - (Math.ceil(length / 2) - 2)
+    )}`
+  else if (position === 'right') return `${str.substr(0, length - 3)}...`
+  else return str.substr(0, length)
+}

--- a/src/utils/string.test.js
+++ b/src/utils/string.test.js
@@ -1,4 +1,4 @@
-import { constantToCamelCase, camelToTitleCase } from './string'
+import { constantToCamelCase, camelToTitleCase, shorten } from './string'
 
 const constant = 'HELLO_CRYPTO_WORLD'
 const camelCase = 'helloCryptoWorld'
@@ -21,3 +21,23 @@ describe('constantToCamelCase', () => {
 describe('camelToTitleCase', () =>
   it('converts camel case strings to title case.', () =>
     expect(camelToTitleCase(camelCase)).toBe(titleCase)))
+
+describe('shorten', () => {
+  it('properly shortens a string with a middle cut', () => {
+    expect(shorten(constant, 5)).toEqual('H...D')
+    expect(shorten(constant, 6)).toEqual('HE...D')
+    expect(shorten(constant, 7)).toEqual('HE...LD')
+  })
+
+  it('properly shortens a string with a right cut', () =>
+    expect(shorten(constant, 5, { position: 'right' })).toEqual('HE...'))
+
+  it("returns a string if the length is bigger than string's length", () =>
+    expect(shorten(constant, 18)).toEqual(constant))
+
+  it('returns prefix if length is smaller than 5', () =>
+    expect(shorten(constant, 3)).toEqual('HEL'))
+
+  it('returns prefix if unknown position is specified', () =>
+    expect(shorten(constant, 5, { position: 'foo' })).toEqual('HELLO'))
+})


### PR DESCRIPTION
The point of this PR was to resolve #23.
However, I think that it makes more sense to have a generic function for shortening strings, rather than one address-specific, as it may be used for strings other than addresses.